### PR TITLE
Update sample time limits to 10000 units

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 This 4 channel scope chip allows you to graph four analog or digital signals as they vary over time.
 
-- Scope `Sample Time μs` range is 0µs to 400µs
+- Scope `Sample Time μs` range is 0µs to 10000µs
 
-- Scope `Sample Time ms` range is 0ms to 40ms .
+- Scope `Sample Time ms` range is 0ms to 10000ms .
 
 - Width of plot is 250 samples.
 

--- a/src/main.c
+++ b/src/main.c
@@ -313,12 +313,12 @@ void chip_init(void) {
 
    chip->sampleTimeUs_attr = attr_init("sampleTimeUs", 0);
   chip->sampleTimeUs = attr_read(chip->sampleTimeUs_attr);
-  if (chip->sampleTimeUs > 400) chip->sampleTimeUs = 400;
+  if (chip->sampleTimeUs > 10000) chip->sampleTimeUs = 10000;
   chip->SampleTimeUs_attr = attr_init("SampleTimeUs", chip->sampleTimeUs);
 
   chip->sampleTimeMs_attr = attr_init("sampleTimeMs", 0);
   chip->sampleTimeMs = attr_read(chip->sampleTimeMs_attr);
-  if (chip->sampleTimeMs > 40) chip->sampleTimeMs = 40;
+  if (chip->sampleTimeMs > 10000) chip->sampleTimeMs = 10000;
   chip->SampleTimeMs_attr = attr_init("SampleTimeMs", chip->sampleTimeMs);
 
   chip->triggerChannel_attr = attr_init("triggerChannel", 0);


### PR DESCRIPTION
I made a tiny edit to the main.c file to allow for users to slow down the sampling even more (up to 10000 microseconds, or up to 10000 milliseconds) so they can control the timing more precisely.